### PR TITLE
Add Limit Range Admission Controller.

### DIFF
--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 	"k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages"
 	"k8s.io/kubernetes/plugin/pkg/admission/antiaffinity"
+	"k8s.io/kubernetes/plugin/pkg/admission/decorategpupod"
 	"k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds"
 	"k8s.io/kubernetes/plugin/pkg/admission/deny"
 	"k8s.io/kubernetes/plugin/pkg/admission/exec"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/imagepolicy"
 	"k8s.io/kubernetes/plugin/pkg/admission/initialization"
 	"k8s.io/kubernetes/plugin/pkg/admission/initialresources"
+	"k8s.io/kubernetes/plugin/pkg/admission/limitpolicy"
 	"k8s.io/kubernetes/plugin/pkg/admission/limitranger"
 	"k8s.io/kubernetes/plugin/pkg/admission/namespace/autoprovision"
 	"k8s.io/kubernetes/plugin/pkg/admission/namespace/exists"
@@ -49,7 +51,6 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 	"k8s.io/kubernetes/plugin/pkg/admission/storageclass/setdefault"
 	"k8s.io/kubernetes/plugin/pkg/admission/webhook"
-	"k8s.io/kubernetes/plugin/pkg/admission/decorategpupod"
 )
 
 // registerAllAdmissionPlugins registers all admission plugins
@@ -79,4 +80,5 @@ func registerAllAdmissionPlugins(plugins *admission.Plugins) {
 	setdefault.Register(plugins)
 	webhook.Register(plugins)
 	decorategpupod.Register(plugins)
+	limitpolicy.Register(plugins)
 }

--- a/plugin/pkg/admission/limitpolicy/BUILD
+++ b/plugin/pkg/admission/limitpolicy/BUILD
@@ -1,0 +1,44 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["admission_test.go"],
+    library = ":go_default_library",
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/api/helper:go_default_library",
+        "//plugin/pkg/scheduler/algorithm:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["admission.go"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/api/helper:go_default_library",
+        "//plugin/pkg/scheduler/algorithm:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/plugin/pkg/admission/limitpolicy/admission.go
+++ b/plugin/pkg/admission/limitpolicy/admission.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitpolicy
+
+import (
+	"io"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("LimitPolicy", func(config io.Reader) (admission.Interface, error) {
+		return NewLimitPolicyPlugin(), nil
+	})
+}
+
+// plugin contains the client used by the admission controller
+type plugin struct {
+	*admission.Handler
+}
+
+// NewLimitPolicyPlugin creates a new instance of the LimitPolicy admission controller
+func NewLimitPolicyPlugin() admission.Interface {
+	return &plugin{
+		Handler: admission.NewHandler(admission.Create),
+	}
+}
+
+// check if a pod need to limit
+// only GPU pod need to limit
+func checkUpdateLimitResource(pod *api.Pod) bool {
+	isNeed := false
+	// TODO: check if pod spec has defined "limit policy"
+	containers := pod.Spec.Containers
+	for _, container := range containers {
+		gpu_limit, ok := container.Resources.Limits.NvidiaGPU().AsInt64()
+		if ok && gpu_limit > 0 {
+			isNeed = true
+			break
+		}
+	}
+	return isNeed
+}
+
+// check if resource requirement is set
+func checkSetResource(r *api.ResourceRequirements) bool {
+	check := false
+	// check if resource requirement is set
+	if r != nil {
+		if len(r.Limits) != 0 || len(r.Requests) != 0 {
+			check = true
+		}
+	}
+	return check
+}
+
+// set resource requirements into a package
+func setLimitRangeResource(r *api.ResourceRequirements) {
+	cpuRangeLimits := []resource.Quantity{
+		resource.MustParse("1"),
+		resource.MustParse("2"),
+		resource.MustParse("4"),
+		resource.MustParse("8"),
+		// TODO:
+	}
+	cpuRangeRequests := []r.Quantity{
+		resource.MustParse("1"),
+		resource.MustParse("2"),
+		resource.MustParse("4"),
+		resource.MustParse("8"),
+	}
+
+	memRangeLimits := []r.Quantity{
+		resource.MustParse("128"),
+		resource.MustParse("256"),
+		resource.MustParse("512"),
+		resource.MustParse("1Gi"),
+	}
+	memRangeRequests := []r.Quantity{
+		resource.MustParse("128"),
+		resource.MustParse("256"),
+		resource.MustParse("512"),
+		resource.MustParse("1Gi"),
+	}
+	// set resource limits
+	if len(r.Limits) != 0 {
+		if _, ok := r.Limits[api.ResourceCPU]; ok {
+			for _, c := range cpuRangeLimits {
+				if c.Cmp(r.Limits[api.ResourceCPU]) == 1 {
+					r.Limits[api.ResourceCPU] = c
+					break
+				}
+			}
+		} else {
+			r.Limits[api.ResourceCPU] = resource.MustParse("1")
+		}
+		if _, ok := r.Limits[api.ResourceMemory]; ok {
+			for _, c := range memRangeLimits {
+				if c.Cmp(r.Limits[api.ResourceMemory]) == 1 {
+					r.Limits[api.ResourceMemory] = c
+					break
+				}
+			}
+		} else {
+			r.Limits[api.ResourceMemory] = resource.MustParse("128Mem")
+		}
+	}
+	// set resource requests
+	if len(resource.Requests) != 0 {
+		if _, ok := r.Requests[api.ResourceCPU]; ok {
+			for _, c := range cpuRangeRequests {
+				if c.Cmp(r.Requests[api.ResourceCPU]) == 1 {
+					r.Requests[api.ResourceCPU] = c
+					break
+				}
+			}
+		} else {
+			r.Requests[api.ResourceCPU] = resource.MustParse("1")
+		}
+		if _, ok := resource.Requests[api.ResourceMemory]; ok {
+			for _, c := range memRangeRequests {
+				if r.Cmp(resource.Requests[api.ResourceMemory]) == 1 {
+					resource.Requests[api.ResourceMemory] = c
+					break
+				}
+			}
+		} else {
+			r.Requests[api.ResourceMemory] = resource.MustParse("128Mem")
+		}
+	}
+}
+
+// set resource requirements to be default value
+func setDefaultRangeResource(resource *api.ResourceRequirements) {
+	// set resource limits
+	defaultLimitResource := api.ResourceList{
+		api.ResourceCPU:       r.MustParse("1"),
+		api.ResourceMemory:    r.MustParse("128Mem"),
+		api.ResourceNvidiaGPU: r.MustParse("1"),
+		/*
+			api.ResourceStorage: r.MustParse("1"),
+			api.ResourceStorageOverlay: r.MustParse("1"),
+			api.ResourceStorageScratch: r.MustParse("1"),
+		*/
+	}
+	resource.Limits = defaultLimitResource
+	// set resource requests
+	defaultRequestResource := api.ResourceList{
+		api.ResourceCPU:       r.MustParse("1"),
+		api.ResourceMemory:    r.MustParse("128Mem"),
+		api.ResourceNvidiaGPU: r.MustParse("1"),
+		/*
+			api.ResourceStorage: r.MustParse("1"),
+			api.ResourceStorageOverlay: r.MustParse("1"),
+			api.ResourceStorageScratch: r.MustParse("1"),
+		*/
+	}
+	resource.Requests = defaultRequestResource
+}
+
+/*
+ * update the containers resource requirements into a package.
+ * 1u 128M
+ * 2u 256M
+ * ...
+ */
+func updateLimitResource(pod *api.Pod) {
+	// update init containers
+	for i, c := range pod.Spec.InitContainers {
+		if set := checkSetResource(c.Resources); set {
+			setLimitRangeResource(&c.Resources)
+		} else {
+			setDefaultRangeResource(&c.Resources)
+		}
+	}
+	// update containers
+	for i, c := range pod.Spec.InitContainers {
+		if set := checkSetResource(c.Resources); set {
+			setLimitRangeResource(&c.Resources)
+		} else {
+			setDefaultRangeResource(&c.Resources)
+		}
+	}
+}
+
+// Admit will update resource requirements for containers when pod creating
+func (p *plugin) Admit(a admission.Attributes) (err error) {
+	// Ignore all calls to subresources or resources other than pods.
+	if len(a.GetSubresource()) != 0 || a.GetResource().GroupResource() != api.Resource("pods") {
+		return nil
+	}
+
+	if a.GetOperation() != admission.Create {
+		return nil
+	}
+
+	pod, ok := a.GetObject().(*api.Pod)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+	}
+
+	if !checkUpdateLimitResource(pod) {
+		return nil
+	} else {
+		updateLimitResource(pod)
+	}
+
+	return nil
+}
+
+func (p *plugin) Handles(operation admission.Operation) bool {
+	if operation == admission.Create {
+		return true
+	}
+	return false
+}

--- a/plugin/pkg/admission/limitpolicy/admission_test.go
+++ b/plugin/pkg/admission/limitpolicy/admission_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitpolicy
+
+import (
+	"strconv"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func getPod(name, cpu, gpu, mem string) *api.Pod {
+	res := api.ResourceRequirements{}
+	res.Requests = api.ResourceList{
+		api.ResourceCPU: resource.MustParse(cpu),
+		api.ResourceMemory: resource.MustParse(mem),
+		api.ResourceNvidiaGPU: resource.MustParse(gpu),
+	}
+	res.Limits = api.ResourceList{
+		api.ResourceCPU: resource.MustParse(cpu),
+		api.ResourceMemory: resource.MustParse(mem),
+		api.ResourceNvidiaGPU: resource.MustParse(gpu),
+	}
+
+	pod := &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test"},
+		Spec:       api.PodSpec{},
+	}
+	pod.Spec.Containers = make([]api.Container, 0, numContainers)
+	for i := 0; i < numContainers; i++ {
+		pod.Spec.Containers = append(pod.Spec.Containers, api.Container{
+			Image:     "foo:V" + strconv.Itoa(i),
+			Resources: res,
+		})
+	}
+
+	return pod
+}
+
+func checkFieldEqual(a, b resource.Quantity) {
+	if a.cmp(b) == 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
+func assertAllFieldsEquality(pod *api.Pod, want *api.Pod) {
+	for i, c := range pod.Spec.InitContainers {
+		l := c.Resources
+		w := want.Spec.InitContainers[i].Resources
+		if !checkFieldEqual(l.Limits[api.ResourceCPU], w.Limits[api.ResourceCPU])
+		|| !checkFieldEqual(l.Limits[api.ResourceMemory], w.Limits[api.ResourceMemory])
+		|| !checkFieldEqual(l.Limits[api.ResourceNvidiaGPU], w.Limits[api.ResourceNvidiaGPU]) {
+			return false
+		}
+		if !checkFieldEqual(l.Requests[api.ResourceCPU], w.Requests[api.ResourceCPU])
+		|| !checkFieldEqual(l.Requests[api.ResourceMemory], w.Requests[api.ResourceMemory])
+		|| !checkFieldEqual(l.Requests[api.ResourceNvidiaGPU], w.Requests[api.ResourceNvidiaGPU]) {
+			return false
+		}
+	}
+	for i, c := range pod.Spec.Containers {
+		l := c.Resources
+		w := want.Spec.Containers[i].Resources
+		if !checkFieldEqual(l.Limits[api.ResourceCPU], w.Limits[api.ResourceCPU])
+		|| !checkFieldEqual(l.Limits[api.ResourceMemory], w.Limits[api.ResourceMemory])
+		|| !checkFieldEqual(l.Limits[api.ResourceNvidiaGPU], w.Limits[api.ResourceNvidiaGPU]) {
+			return false
+		}
+		if !checkFieldEqual(l.Requests[api.ResourceCPU], w.Requests[api.ResourceCPU])
+		|| !checkFieldEqual(l.Requests[api.ResourceMemory], w.Requests[api.ResourceMemory])
+		|| !checkFieldEqual(l.Requests[api.ResourceNvidiaGPU], w.Requests[api.ResourceNvidiaGPU]) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestAdmit(t *testing.T) {
+	handler := NewLimitPolicyPlugin()
+	testCases := []struct {
+		Pod *api.Pod,
+		Want, *api.Pod
+	}{
+		{
+			getPod("test", "1", "2", "128Mem")
+			getPod("test", 1, "1", "128Mem")
+		},
+		{
+			getPod("test", 1, "2", "512Mem")
+			getPod("test", 2, "2", "256Mem")
+		}
+	}
+	for _, c := range testCases {
+		if err := handler.Admit(admission.NewAttributesRecord(newPod, nil, 
+				api.Kind("Pod").WithVersion("version"), 
+				newPod.Namespace, newPod.Name, 
+				api.Resource("pods").WithVersion("version"), "", 
+				admission.Create, nil)); err != nil {
+			t.Errorf("Unexpected error returned from admission handler")
+		}
+		if check := assertAllFieldsEquality(c.Pod, c.Want); !check {
+			t.Errorf("Expect pod: %#v\n But got pod: %#v\n", c.Want, c.Pod)
+		} 
+	}
+}
+
+func TestHandles(t *testing.T) {
+	for op, shouldHandle := range map[admission.Operation]bool{
+		admission.Create:  true,
+		admission.Update:  false,
+		admission.Connect: false,
+		admission.Delete:  false,
+	} {
+		handler := NewLimitPolicyPlugin()
+		if e, a := shouldHandle, handler.Handles(op); e != a {
+			t.Errorf("%v: shouldHandle=%t, handles=%t", op, e, a)
+		}
+	}
+}


### PR DESCRIPTION
#### 背景
为了使得GPU资源的申请和分配更加的合理和可控，增加了`limit policy admission controller`，可以动态修改`workload`的资源申请信息。
#### 目标
使得资源的分配更加的合理，比如用户申请了
```
1核CPU
1卡GPU
2Gi内存
```
那么需要进行更正如下（Demo）：
```
1核CPU
1卡GPU
128Mem内存
```
#### 进度
- `plugin/pkg/admission/limitpolicy/admission.go` 实现基本的框架，缺少`setLimitRangeResource`的具体实现，因为GPU的资源使用配置信息还没有确定下来。
- `plugin/pkg/admission/limitpolicy/admission_test.go` 实现基本的测试框架，不过`testCases`需要完善，原因同上。
