### PR TITLE
Add gpu encoder decoder utilization metrics function.

### DIFF
--- a/vendor/github.com/google/cadvisor/accelerators/nvidia.go
+++ b/vendor/github.com/google/cadvisor/accelerators/nvidia.go
@@ -220,6 +220,14 @@ func (nc *NvidiaCollector) UpdateStats(stats *info.ContainerStats) error {
 		if err != nil {
 			return fmt.Errorf("error while getting gpu memory info: %v", err)
 		}
+		utilizationEncoder, _, err := device.EncoderUtilization()
+		if err != nil {
+			return fmt.Errorf("error while getting gpu encoder info: %v", err)
+		}
+		utilizationDecoder, _, err := device.DecoderUtilization()
+		if err != nil {
+			return fmt.Errorf("error while getting gpu decoder info: %v", err)
+		}
 		//TODO: Use housekeepingInterval
 		utilizationGPU, err := device.AverageGPUUtilization(10 * time.Second)
 		if err != nil {
@@ -227,12 +235,14 @@ func (nc *NvidiaCollector) UpdateStats(stats *info.ContainerStats) error {
 		}
 
 		stats.Accelerators = append(stats.Accelerators, info.AcceleratorStats{
-			Make:        "nvidia",
-			Model:       model,
-			ID:          uuid,
-			MemoryTotal: memoryTotal,
-			MemoryUsed:  memoryUsed,
-			DutyCycle:   uint64(utilizationGPU),
+			Make:               "nvidia",
+			Model:              model,
+			ID:                 uuid,
+			MemoryTotal:        memoryTotal,
+			MemoryUsed:         memoryUsed,
+			DutyCycle:          uint64(utilizationGPU),
+			EncoderUtilization: uint64(utilizationEncoder),
+			DecoderUtilization: uint64(utilizationDecoder),
 		})
 	}
 	return nil

--- a/vendor/github.com/google/cadvisor/info/v1/container.go
+++ b/vendor/github.com/google/cadvisor/info/v1/container.go
@@ -547,6 +547,12 @@ type AcceleratorStats struct {
 	// Percent of time over the past sample period during which
 	// the accelerator was actively processing.
 	DutyCycle uint64 `json:"duty_cycle"`
+
+	// Utilization of encoder
+	EncoderUtilization uint64 `json:encoder_utilization`
+
+	// Utilization of decoder
+	DecoderUtilization uint64 `json:decoder_utilization`
 }
 
 type ContainerStats struct {

--- a/vendor/github.com/google/cadvisor/metrics/prometheus.go
+++ b/vendor/github.com/google/cadvisor/metrics/prometheus.go
@@ -317,6 +317,36 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc) *PrometheusCo
 					return values
 				},
 			}, {
+				name:        "container_accelerator_encoder_utilization",
+				help:        "Accelerator encoder utilization",
+				valueType:   prometheus.GaugeValue,
+				extraLabels: []string{"make", "model", "acc_id"},
+				getValues: func(s *info.ContainerStats) metricValues {
+					values := make(metricValues, 0, len(s.Accelerators))
+					for _, value := range s.Accelerators {
+						values = append(values, metricValue{
+							value:  float64(value.EncoderUtilization),
+							labels: []string{value.Make, value.Model, value.ID},
+						})
+					}
+					return values
+				},
+			}, {
+				name:        "container_accelerator_decoder_utilization",
+				help:        "Accelerator decoder utilization",
+				valueType:   prometheus.GaugeValue,
+				extraLabels: []string{"make", "model", "acc_id"},
+				getValues: func(s *info.ContainerStats) metricValues {
+					values := make(metricValues, 0, len(s.Accelerators))
+					for _, value := range s.Accelerators {
+						values = append(values, metricValue{
+							value:  float64(value.DecoderUtilization),
+							labels: []string{value.Make, value.Model, value.ID},
+						})
+					}
+					return values
+				},
+			}, {
 				name:        "container_fs_inodes_free",
 				help:        "Number of available Inodes",
 				valueType:   prometheus.GaugeValue,


### PR DESCRIPTION
Merged from https://github.com/qbox/cadvisor/pull/2.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
