### PR TITLE
Pass monitors addresses in a comma-separated list instead of trying one

### DIFF
--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path"
 	"regexp"
@@ -112,6 +111,20 @@ type RBDUtil struct{}
 func (util *RBDUtil) MakeGlobalPDName(rbd rbd) string {
 	return makePDNameInternal(rbd.plugin.host, rbd.Pool, rbd.Image)
 }
+
+// 'rbd' utility builds a comma-separated list of monitor addresses from '-m' /
+// '--mon_host` parameter (comma, semi-colon, or white-space delimited monitor
+// addresses) and send it to kernel rbd/libceph modules, which can accept
+// comma-seprated list of monitor addresses (e.g. ip1[:port1][,ip2[:port2]...])
+// in theirs first version in linux (see
+// https://github.com/torvalds/linux/blob/602adf400201636e95c3fed9f31fba54a3d7e844/net/ceph/ceph_common.c#L239).
+// Also, libceph module choose monitor randomly, so we can simply pass all
+// addresses without randomization (see
+// https://github.com/torvalds/linux/blob/602adf400201636e95c3fed9f31fba54a3d7e844/net/ceph/mon_client.c#L132).
+func (util *RBDUtil) kernelRBDMonitorsOpt(mons []string) string {
+	return strings.Join(mons, ",")
+}
+
 func rbdErrors(runErr, resultErr error) error {
 	if runErr.Error() == rbdCmdErr {
 		return fmt.Errorf("rbd: rbd cmd not found")
@@ -140,74 +153,64 @@ func (util *RBDUtil) rbdLock(b rbdMounter, lock bool) error {
 	// construct lock id using host name and a magic prefix
 	lock_id := kubeLockMagic + node.GetHostname("")
 
-	l := len(b.Mon)
-	// avoid mount storm, pick a host randomly
-	start := rand.Int() % l
-	// iterate all hosts until mount succeeds.
-	for i := start; i < start+l; i++ {
-		mon := b.Mon[i%l]
-		// cmd "rbd lock list" serves two purposes:
-		// for fencing, check if lock already held for this host
-		// this edge case happens if host crashes in the middle of acquiring lock and mounting rbd
-		// for defencing, get the locker name, something like "client.1234"
-		args := []string{"lock", "list", b.Image, "--pool", b.Pool, "--id", b.Id, "-m", mon}
-		args = append(args, secret_opt...)
-		cmd, err = b.exec.Run("rbd", args...)
-		output = string(cmd)
-		glog.Infof("lock list output %q", output)
-		if err != nil {
-			continue
-		}
+	mon := util.kernelRBDMonitorsOpt(b.Mon)
+	// cmd "rbd lock list" serves two purposes:
+	// for fencing, check if lock already held for this host
+	// this edge case happens if host crashes in the middle of acquiring lock and mounting rbd
+	// for defencing, get the locker name, something like "client.1234"
+	args := []string{"lock", "list", b.Image, "--pool", b.Pool, "--id", b.Id, "-m", mon}
+	args = append(args, secret_opt...)
+	cmd, err = b.exec.Run("rbd", args...)
+	output = string(cmd)
+	glog.Infof("lock list output %q", output)
+	if err != nil {
+		return err
+	}
 
-		if lock {
-			// check if lock is already held for this host by matching lock_id and rbd lock id
-			if strings.Contains(output, lock_id) {
-				// this host already holds the lock, exit
-				glog.V(1).Infof("rbd: lock already held for %s", lock_id)
-				return nil
-			}
-			// clean up orphaned lock if no watcher on the image
-			used, statusErr := util.rbdStatus(&b)
-			if statusErr == nil && !used {
-				re := regexp.MustCompile("client.* " + kubeLockMagic + ".*")
-				locks := re.FindAllStringSubmatch(output, -1)
-				for _, v := range locks {
-					if len(v) > 0 {
-						lockInfo := strings.Split(v[0], " ")
-						if len(lockInfo) > 2 {
-							args := []string{"lock", "remove", b.Image, lockInfo[1], lockInfo[0], "--pool", b.Pool, "--id", b.Id, "-m", mon}
-							args = append(args, secret_opt...)
-							cmd, err = b.exec.Run("rbd", args...)
-							glog.Infof("remove orphaned locker %s from client %s: err %v, output: %s", lockInfo[1], lockInfo[0], err, string(cmd))
-						}
+	if lock {
+		// check if lock is already held for this host by matching lock_id and rbd lock id
+		if strings.Contains(output, lock_id) {
+			// this host already holds the lock, exit
+			glog.V(1).Infof("rbd: lock already held for %s", lock_id)
+			return nil
+		}
+		// clean up orphaned lock if no watcher on the image
+		used, statusErr := util.rbdStatus(&b)
+		if statusErr == nil && !used {
+			re := regexp.MustCompile("client.* " + kubeLockMagic + ".*")
+			locks := re.FindAllStringSubmatch(output, -1)
+			for _, v := range locks {
+				if len(v) > 0 {
+					lockInfo := strings.Split(v[0], " ")
+					if len(lockInfo) > 2 {
+						args := []string{"lock", "remove", b.Image, lockInfo[1], lockInfo[0], "--pool", b.Pool, "--id", b.Id, "-m", mon}
+						args = append(args, secret_opt...)
+						cmd, err = b.exec.Run("rbd", args...)
+						glog.Infof("remove orphaned locker %s from client %s: err %v, output: %s", lockInfo[1], lockInfo[0], err, string(cmd))
 					}
 				}
 			}
+		}
 
-			// hold a lock: rbd lock add
-			args := []string{"lock", "add", b.Image, lock_id, "--pool", b.Pool, "--id", b.Id, "-m", mon}
-			args = append(args, secret_opt...)
-			cmd, err = b.exec.Run("rbd", args...)
-		} else {
-			// defencing, find locker name
-			ind := strings.LastIndex(output, lock_id) - 1
-			for i := ind; i >= 0; i-- {
-				if output[i] == '\n' {
-					locker = output[(i + 1):ind]
-					break
-				}
+		// hold a lock: rbd lock add
+		args := []string{"lock", "add", b.Image, lock_id, "--pool", b.Pool, "--id", b.Id, "-m", mon}
+		args = append(args, secret_opt...)
+		cmd, err = b.exec.Run("rbd", args...)
+	} else {
+		// defencing, find locker name
+		ind := strings.LastIndex(output, lock_id) - 1
+		for i := ind; i >= 0; i-- {
+			if output[i] == '\n' {
+				locker = output[(i + 1):ind]
+				break
 			}
-			// remove a lock: rbd lock remove
-			args := []string{"lock", "remove", b.Image, lock_id, locker, "--pool", b.Pool, "--id", b.Id, "-m", mon}
-			args = append(args, secret_opt...)
-			cmd, err = b.exec.Run("rbd", args...)
 		}
-
-		if err == nil {
-			//lock is acquired
-			break
-		}
+		// remove a lock: rbd lock remove
+		args := []string{"lock", "remove", b.Image, lock_id, locker, "--pool", b.Pool, "--id", b.Id, "-m", mon}
+		args = append(args, secret_opt...)
+		cmd, err = b.exec.Run("rbd", args...)
 	}
+
 	return err
 }
 
@@ -296,26 +299,16 @@ func (util *RBDUtil) AttachDisk(b rbdMounter) error {
 		// the json file remains invisible during rbd mount and thus won't be removed accidentally.
 		util.persistRBD(b, globalPDPath)
 
-		// rbd map
-		l := len(b.Mon)
-		// avoid mount storm, pick a host randomly
-		start := rand.Int() % l
-		// iterate all hosts until mount succeeds.
-		for i := start; i < start+l; i++ {
-			mon := b.Mon[i%l]
-			glog.V(1).Infof("rbd: map mon %s", mon)
-			if b.Secret != "" {
-				output, err = b.exec.Run("rbd",
-					"map", b.Image, "--pool", b.Pool, "--id", b.Id, "-m", mon, "--key="+b.Secret)
-			} else {
-				output, err = b.exec.Run("rbd",
-					"map", b.Image, "--pool", b.Pool, "--id", b.Id, "-m", mon, "-k", b.Keyring)
-			}
-			if err == nil {
-				break
-			}
-			glog.V(1).Infof("rbd: map error %v %s", err, string(output))
+		mon := util.kernelRBDMonitorsOpt(b.Mon)
+		glog.V(1).Infof("rbd: map mon %s", mon)
+		if b.Secret != "" {
+			output, err = b.exec.Run("rbd",
+				"map", b.Image, "--pool", b.Pool, "--id", b.Id, "-m", mon, "--key="+b.Secret)
+		} else {
+			output, err = b.exec.Run("rbd",
+				"map", b.Image, "--pool", b.Pool, "--id", b.Id, "-m", mon, "-k", b.Keyring)
 		}
+		glog.V(1).Infof("rbd: map error %v %s", err, string(output))
 		if err != nil {
 			return fmt.Errorf("rbd: map failed %v %s", err, string(output))
 		}
@@ -369,31 +362,22 @@ func (util *RBDUtil) CreateImage(p *rbdVolumeProvisioner) (r *v1.RBDVolumeSource
 	// convert to MB that rbd defaults on
 	sz := int(volume.RoundUpSize(volSizeBytes, 1024*1024))
 	volSz := fmt.Sprintf("%d", sz)
-	// rbd create
-	l := len(p.rbdMounter.Mon)
-	// pick a mon randomly
-	start := rand.Int() % l
-	// iterate all monitors until create succeeds.
-	for i := start; i < start+l; i++ {
-		mon := p.Mon[i%l]
-		if p.rbdMounter.imageFormat == rbdImageFormat2 {
-			glog.V(4).Infof("rbd: create %s size %s format %s (features: %s) using mon %s, pool %s id %s key %s", p.rbdMounter.Image, volSz, p.rbdMounter.imageFormat, p.rbdMounter.imageFeatures, mon, p.rbdMounter.Pool, p.rbdMounter.adminId, p.rbdMounter.adminSecret)
-		} else {
-			glog.V(4).Infof("rbd: create %s size %s format %s using mon %s, pool %s id %s key %s", p.rbdMounter.Image, volSz, p.rbdMounter.imageFormat, mon, p.rbdMounter.Pool, p.rbdMounter.adminId, p.rbdMounter.adminSecret)
-		}
-		args := []string{"create", p.rbdMounter.Image, "--size", volSz, "--pool", p.rbdMounter.Pool, "--id", p.rbdMounter.adminId, "-m", mon, "--key=" + p.rbdMounter.adminSecret, "--image-format", p.rbdMounter.imageFormat}
-		if p.rbdMounter.imageFormat == rbdImageFormat2 {
-			// if no image features is provided, it results in empty string
-			// which disable all RBD image format 2 features as we expected
-			features := strings.Join(p.rbdMounter.imageFeatures, ",")
-			args = append(args, "--image-feature", features)
-		}
-		output, err = p.exec.Run("rbd", args...)
-		if err == nil {
-			break
-		} else {
-			glog.Warningf("failed to create rbd image, output %v", string(output))
-		}
+	mon := util.kernelRBDMonitorsOpt(p.Mon)
+	if p.rbdMounter.imageFormat == rbdImageFormat2 {
+		glog.V(4).Infof("rbd: create %s size %s format %s (features: %s) using mon %s, pool %s id %s key %s", p.rbdMounter.Image, volSz, p.rbdMounter.imageFormat, p.rbdMounter.imageFeatures, mon, p.rbdMounter.Pool, p.rbdMounter.adminId, p.rbdMounter.adminSecret)
+	} else {
+		glog.V(4).Infof("rbd: create %s size %s format %s using mon %s, pool %s id %s key %s", p.rbdMounter.Image, volSz, p.rbdMounter.imageFormat, mon, p.rbdMounter.Pool, p.rbdMounter.adminId, p.rbdMounter.adminSecret)
+	}
+	args := []string{"create", p.rbdMounter.Image, "--size", volSz, "--pool", p.rbdMounter.Pool, "--id", p.rbdMounter.adminId, "-m", mon, "--key=" + p.rbdMounter.adminSecret, "--image-format", p.rbdMounter.imageFormat}
+	if p.rbdMounter.imageFormat == rbdImageFormat2 {
+		// if no image features is provided, it results in empty string
+		// which disable all RBD image format 2 features as we expected
+		features := strings.Join(p.rbdMounter.imageFeatures, ",")
+		args = append(args, "--image-feature", features)
+	}
+	output, err = p.exec.Run("rbd", args...)
+	if err != nil {
+		glog.Warningf("failed to create rbd image, output %v", string(output))
 	}
 
 	if err != nil {
@@ -418,20 +402,14 @@ func (util *RBDUtil) DeleteImage(p *rbdVolumeDeleter) error {
 		return fmt.Errorf("rbd %s is still being used", p.rbdMounter.Image)
 	}
 	// rbd rm
-	l := len(p.rbdMounter.Mon)
-	// pick a mon randomly
-	start := rand.Int() % l
-	// iterate all monitors until rm succeeds.
-	for i := start; i < start+l; i++ {
-		mon := p.rbdMounter.Mon[i%l]
-		glog.V(4).Infof("rbd: rm %s using mon %s, pool %s id %s key %s", p.rbdMounter.Image, mon, p.rbdMounter.Pool, p.rbdMounter.adminId, p.rbdMounter.adminSecret)
-		output, err = p.exec.Run("rbd",
-			"rm", p.rbdMounter.Image, "--pool", p.rbdMounter.Pool, "--id", p.rbdMounter.adminId, "-m", mon, "--key="+p.rbdMounter.adminSecret)
-		if err == nil {
-			return nil
-		} else {
-			glog.Errorf("failed to delete rbd image: %v, command output: %s", err, string(output))
-		}
+	mon := util.kernelRBDMonitorsOpt(p.rbdMounter.Mon)
+	glog.V(4).Infof("rbd: rm %s using mon %s, pool %s id %s key %s", p.rbdMounter.Image, mon, p.rbdMounter.Pool, p.rbdMounter.adminId, p.rbdMounter.adminSecret)
+	output, err = p.exec.Run("rbd",
+		"rm", p.rbdMounter.Image, "--pool", p.rbdMounter.Pool, "--id", p.rbdMounter.adminId, "-m", mon, "--key="+p.rbdMounter.adminSecret)
+	if err == nil {
+		return nil
+	} else {
+		glog.Errorf("failed to delete rbd image: %v, command output: %s", err, string(output))
 	}
 	return err
 }
@@ -442,35 +420,30 @@ func (util *RBDUtil) rbdStatus(b *rbdMounter) (bool, error) {
 	var output string
 	var cmd []byte
 
-	l := len(b.Mon)
-	start := rand.Int() % l
-	// iterate all hosts until mount succeeds.
-	for i := start; i < start+l; i++ {
-		mon := b.Mon[i%l]
-		// cmd "rbd status" list the rbd client watch with the following output:
-		// Watchers:
-		//   watcher=10.16.153.105:0/710245699 client.14163 cookie=1
-		glog.V(4).Infof("rbd: status %s using mon %s, pool %s id %s key %s", b.Image, mon, b.Pool, b.adminId, b.adminSecret)
-		cmd, err = b.exec.Run("rbd",
-			"status", b.Image, "--pool", b.Pool, "-m", mon, "--id", b.adminId, "--key="+b.adminSecret)
-		output = string(cmd)
+	mon := util.kernelRBDMonitorsOpt(b.Mon)
+	// cmd "rbd status" list the rbd client watch with the following output:
+	// Watchers:
+	//   watcher=10.16.153.105:0/710245699 client.14163 cookie=1
+	glog.V(4).Infof("rbd: status %s using mon %s, pool %s id %s key %s", b.Image, mon, b.Pool, b.adminId, b.adminSecret)
+	cmd, err = b.exec.Run("rbd",
+		"status", b.Image, "--pool", b.Pool, "-m", mon, "--id", b.adminId, "--key="+b.adminSecret)
+	output = string(cmd)
 
-		if err != nil {
-			if err.Error() == rbdCmdErr {
-				glog.Errorf("rbd cmd not found")
-			} else {
-				// ignore error code, just checkout output for watcher string
-				glog.Warningf("failed to execute rbd status on mon %s", mon)
-			}
-		}
-
-		if strings.Contains(output, imageWatcherStr) {
-			glog.V(4).Infof("rbd: watchers on %s: %s", b.Image, output)
-			return true, nil
+	if err != nil {
+		if err.Error() == rbdCmdErr {
+			glog.Errorf("rbd cmd not found")
 		} else {
-			glog.Warningf("rbd: no watchers on %s", b.Image)
-			return false, nil
+			// ignore error code, just checkout output for watcher string
+			glog.Warningf("failed to execute rbd status on mon %s", mon)
 		}
+	}
+
+	if strings.Contains(output, imageWatcherStr) {
+		glog.V(4).Infof("rbd: watchers on %s: %s", b.Image, output)
+		return true, nil
+	} else {
+		glog.Warningf("rbd: no watchers on %s", b.Image)
+		return false, nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
by one.

In production, monitors may crash (or have a network problem), if we try
monitors one by one, rbd command will hang a long time (e.g. `rbd map -m
<unconnectable_host_ip>` on linux 4.4 timed out in 6 minutes) when
trying a unconnectable monitor. This is unacceptable.

Actually, we can simply pass a comma-separed list monitor addresses
to `rbd` command utility. Kernel rbd/libceph modules will pick
monitor randomly and try one by one, `rbd` command utility succeed soon
if there is a good one in monitors list.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
