### PR TITLE
Hack container hash method to make it compatible when upgrading cluster from 1.7 to 1.8.

### DIFF
--- a/pkg/kubelet/container/hackhash.go
+++ b/pkg/kubelet/container/hackhash.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package container
+
+import (
+	"hash/fnv"
+	"regexp"
+
+	"k8s.io/api/core/v1"
+	hashutil "k8s.io/kubernetes/pkg/util/hash"
+)
+
+// TODO: Remove when all pods in cluster have no pod-version annotations
+
+const (
+	podVersionLabel   = "k8s.qiniu.com/pod-version"
+	podVersionLabel17 = "1.7"
+)
+
+// Specific func to hack container hash
+func hashContainerExt(container *v1.Container, hackFunc hashutil.HackFunc) uint64 {
+	hash := fnv.New32a()
+	hashutil.DeepHashObjectExt(hash, *container, hackFunc)
+	return uint64(hash.Sum32())
+}
+
+// For container hash compatibility when upgrade cluster from old version.
+// Use different hash method by pod version annotations
+func HashContainerByPodVersion(pod *v1.Pod, container *v1.Container) uint64 {
+	var containerHash uint64
+	version, exists := pod.Annotations[podVersionLabel]
+	if exists && version == podVersionLabel17 {
+		containerHash = hashContainerExt(container, HackContainerHashTo17)
+	} else {
+		containerHash = HashContainer(container)
+	}
+	return containerHash
+}
+
+// Convert container hash from 1.8 to 1.7
+func hackGoString18to17(s string) string {
+	// MountPropagation:(*v1.MountPropagationMode)<nil>
+	re := regexp.MustCompile(`\s*MountPropagation:(.*?)([\s}])`)
+	s = re.ReplaceAllString(s, `${2}`)
+	// AllowPrivilegeEscalation:(*bool)<nil>
+	re = regexp.MustCompile(`\s*AllowPrivilegeEscalation:(.*?)([\s}])`)
+	s = re.ReplaceAllString(s, `${2}`)
+	return s
+}
+
+func HackContainerHashTo17(s string) string {
+	return hackGoString18to17(s)
+}

--- a/pkg/kubelet/container/hackhash_test.go
+++ b/pkg/kubelet/container/hackhash_test.go
@@ -1,0 +1,28 @@
+package container
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/util/hash"
+)
+
+func TestHackContainerHash(t *testing.T) {
+	testcases := []struct {
+		original string
+		expected string
+		hackFunc hash.HackFunc
+	}{
+		{
+			`(v1.Container){Name:(string)kube-proxy Image:(string)index-dev.qiniu.io/kelibrary/kube-proxy-amd64:v1.8.13 Command:([]string)[/usr/local/bin/kube-proxy --config=/var/lib/kube-proxy/config.conf] Args:([]string)<nil> WorkingDir:(string) Ports:([]v1.ContainerPort)<nil> EnvFrom:([]v1.EnvFromSource)<nil> Env:([]v1.EnvVar)<nil> Resources:(v1.ResourceRequirements){Limits:(v1.ResourceList)<nil> Requests:(v1.ResourceList)<nil>} VolumeMounts:([]v1.VolumeMount)[{Name:(string)kube-proxy ReadOnly:(bool)false MountPath:(string)/var/lib/kube-proxy SubPath:(string) MountPropagation:(*v1.MountPropagationMode)<nil>} {Name:(string)xtables-lock ReadOnly:(bool)false MountPath:(string)/run/xtables.lock SubPath:(string) MountPropagation:(*v1.MountPropagationMode)<nil>} {Name:(string)lib-modules ReadOnly:(bool)true MountPath:(string)/lib/modules SubPath:(string) MountPropagation:(*v1.MountPropagationMode)<nil>} {Name:(string)kube-proxy-token-jdlsl ReadOnly:(bool)true MountPath:(string)/var/run/secrets/kubernetes.io/serviceaccount SubPath:(string) MountPropagation:(*v1.MountPropagationMode)<nil>}] LivenessProbe:(*v1.Probe)<nil> ReadinessProbe:(*v1.Probe)<nil> Lifecycle:(*v1.Lifecycle)<nil> TerminationMessagePath:(string)/dev/termination-log TerminationMessagePolicy:(v1.TerminationMessagePolicy)File ImagePullPolicy:(v1.PullPolicy)IfNotPresent SecurityContext:(*v1.SecurityContext){Capabilities:(*v1.Capabilities)<nil> Privileged:(*bool)true SELinuxOptions:(*v1.SELinuxOptions)<nil> RunAsUser:(*int64)<nil> RunAsNonRoot:(*bool)<nil> ReadOnlyRootFilesystem:(*bool)<nil> AllowPrivilegeEscalation:(*bool)<nil>} Stdin:(bool)false StdinOnce:(bool)false TTY:(bool)false}`,
+			`(v1.Container){Name:(string)kube-proxy Image:(string)index-dev.qiniu.io/kelibrary/kube-proxy-amd64:v1.7.3 Command:([]string)[/usr/local/bin/kube-proxy --config=/var/lib/kube-proxy/config.conf] Args:([]string)<nil> WorkingDir:(string) Ports:([]v1.ContainerPort)<nil> EnvFrom:([]v1.EnvFromSource)<nil> Env:([]v1.EnvVar)<nil> Resources:(v1.ResourceRequirements){Limits:(v1.ResourceList)<nil> Requests:(v1.ResourceList)<nil>} VolumeMounts:([]v1.VolumeMount)[{Name:(string)kube-proxy ReadOnly:(bool)false MountPath:(string)/var/lib/kube-proxy SubPath:(string)} {Name:(string)xtables-lock ReadOnly:(bool)false MountPath:(string)/run/xtables.lock SubPath:(string)} {Name:(string)lib-modules ReadOnly:(bool)true MountPath:(string)/lib/modules SubPath:(string)} {Name:(string)kube-proxy-token-jdlsl ReadOnly:(bool)true MountPath:(string)/var/run/secrets/kubernetes.io/serviceaccount SubPath:(string)}] LivenessProbe:(*v1.Probe)<nil> ReadinessProbe:(*v1.Probe)<nil> Lifecycle:(*v1.Lifecycle)<nil> TerminationMessagePath:(string)/dev/termination-log TerminationMessagePolicy:(v1.TerminationMessagePolicy)File ImagePullPolicy:(v1.PullPolicy)IfNotPresent SecurityContext:(*v1.SecurityContext){Capabilities:(*v1.Capabilities)<nil> Privileged:(*bool)true SELinuxOptions:(*v1.SELinuxOptions)<nil> RunAsUser:(*int64)<nil> RunAsNonRoot:(*bool)<nil> ReadOnlyRootFilesystem:(*bool)<nil>} Stdin:(bool)false StdinOnce:(bool)false TTY:(bool)false}`,
+			HackContainerHashTo17,
+		},
+	}
+
+	for _, tc := range testcases {
+		actual := tc.hackFunc(tc.original)
+		if actual != tc.expected {
+			t.Errorf("hack container hash error, expected: \n %s\nactual: \n%s\n", tc.expected, actual)
+		}
+	}
+}

--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -214,7 +214,7 @@ func milliCPUToQuota(milliCPU int64) (quota int64, period int64) {
 // (pod, container) tuple. The key should include the content of the
 // container, so that any change to the container generates a new key.
 func getStableKey(pod *v1.Pod, container *v1.Container) string {
-	hash := strconv.FormatUint(kubecontainer.HashContainer(container), 16)
+	hash := strconv.FormatUint(kubecontainer.HashContainerByPodVersion(pod, container), 16)
 	return fmt.Sprintf("%s_%s_%s_%s_%s", pod.Name, pod.Namespace, string(pod.UID), container.Name, hash)
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -413,8 +413,8 @@ func (m *kubeGenericRuntimeManager) podSandboxChanged(pod *v1.Pod, podStatus *ku
 	return false, sandboxStatus.Metadata.Attempt, sandboxStatus.Id
 }
 
-func containerChanged(container *v1.Container, containerStatus *kubecontainer.ContainerStatus) (uint64, uint64, bool) {
-	expectedHash := kubecontainer.HashContainer(container)
+func containerChanged(pod *v1.Pod, container *v1.Container, containerStatus *kubecontainer.ContainerStatus) (uint64, uint64, bool) {
+	expectedHash := kubecontainer.HashContainerByPodVersion(pod, container)
 	return expectedHash, containerStatus.Hash, containerStatus.Hash != expectedHash
 }
 
@@ -512,7 +512,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(pod *v1.Pod, podStatus *ku
 		// The container is running, but kill the container if any of the following condition is met.
 		reason := ""
 		restart := shouldRestartOnFailure(pod)
-		if expectedHash, actualHash, changed := containerChanged(&container, containerStatus); changed {
+		if expectedHash, actualHash, changed := containerChanged(pod, &container, containerStatus); changed {
 			reason = fmt.Sprintf("Container spec hash changed (%d vs %d).", actualHash, expectedHash)
 			// Restart regardless of the restart policy because the container
 			// spec changed.

--- a/pkg/kubelet/kuberuntime/labels.go
+++ b/pkg/kubelet/kuberuntime/labels.go
@@ -107,7 +107,7 @@ func newContainerLabels(container *v1.Container, pod *v1.Pod) map[string]string 
 // newContainerAnnotations creates container annotations from v1.Container and v1.Pod.
 func newContainerAnnotations(container *v1.Container, pod *v1.Pod, restartCount int) map[string]string {
 	annotations := map[string]string{}
-	annotations[containerHashLabel] = strconv.FormatUint(kubecontainer.HashContainer(container), 16)
+	annotations[containerHashLabel] = strconv.FormatUint(kubecontainer.HashContainerByPodVersion(pod, container), 16)
 	annotations[containerRestartCountLabel] = strconv.Itoa(restartCount)
 	annotations[containerTerminationMessagePathLabel] = container.TerminationMessagePath
 	annotations[containerTerminationMessagePolicyLabel] = string(container.TerminationMessagePolicy)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Hack container hash method to make it compatible when upgrading cluster from 1.7 to 1.8.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Ref: https://jira.qiniu.io/browse/KE-2999

PR for k8s 1.9:
https://github.com/qbox/kubernetes/pull/53

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
