### PR TITLE
Add DecoratorGPUPod feature to k8s 1.9

### DIFF
--- a/cmd/kube-apiserver/app/options/plugins.go
+++ b/cmd/kube-apiserver/app/options/plugins.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 	"k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages"
 	"k8s.io/kubernetes/plugin/pkg/admission/antiaffinity"
+	"k8s.io/kubernetes/plugin/pkg/admission/decorategpupod"
 	"k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds"
 	"k8s.io/kubernetes/plugin/pkg/admission/deny"
 	"k8s.io/kubernetes/plugin/pkg/admission/eventratelimit"
@@ -83,4 +84,5 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	setdefault.Register(plugins)
 	resize.Register(plugins)
 	pvcprotection.Register(plugins)
+	decorategpupod.Register(plugins)
 }

--- a/plugin/pkg/admission/decorategpupod/BUILD
+++ b/plugin/pkg/admission/decorategpupod/BUILD
@@ -1,0 +1,46 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["admission_test.go"],
+    importpath = "k8s.io/kubernetes/plugin/pkg/admission/decorategpupod",
+    library = ":go_default_library",
+    deps = [
+        "//pkg/apis/core:go_default_library",
+        "//pkg/apis/core/helper:go_default_library",
+        "//plugin/pkg/scheduler/algorithm:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["admission.go"],
+    importpath = "k8s.io/kubernetes/plugin/pkg/admission/decorategpupod",
+    deps = [
+        "//pkg/apis/core:go_default_library",
+        "//pkg/apis/core/helper:go_default_library",
+        "//plugin/pkg/scheduler/algorithm:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/plugin/pkg/admission/decorategpupod/admission.go
+++ b/plugin/pkg/admission/decorategpupod/admission.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package decorategpupod
+
+import (
+	"io"
+
+	"github.com/golang/glog"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+const (
+	defaultGPUTaintKey = "node-role.qiniu.com/gpu"
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("DecorateGPUPod", func(config io.Reader) (admission.Interface, error) {
+		return NewDecorateGPUPodPlugin(), nil
+	})
+}
+
+// plugin contains the client used by the admission controller
+type plugin struct {
+	*admission.Handler
+}
+
+// NewDecorateGPUPodPlugin creates a new instance of the DecorateGPUPod admission controller
+func NewDecorateGPUPodPlugin() admission.Interface {
+	return &plugin{
+		Handler: admission.NewHandler(admission.Create),
+	}
+}
+
+// check if a pod is required GPU resource
+func checkNeedGPU(pod *api.Pod) bool {
+	isNeed := false
+	// check if pod spec has defined gpu limitation
+	containers := pod.Spec.Containers
+	for _, container := range containers {
+		gpuLimit, ok := container.Resources.Limits.NvidiaGPU().AsInt64()
+		if ok && gpuLimit > 0 {
+			isNeed = true
+			break
+		}
+	}
+	return isNeed
+}
+
+// add a toleration to pod's spec
+func addToleration(toleration *api.Toleration, pod *api.Pod) {
+	found := -1
+	for i, t := range pod.Spec.Tolerations {
+		if t.Key == toleration.Key && t.Operator == toleration.Operator && t.Value == toleration.Value {
+			found = i
+			break
+		}
+	}
+	// append if not exists
+	// update if exists
+	if found != -1 {
+		glog.Infof("toleration found <%v>, update", found)
+		pod.Spec.Tolerations[found].Effect = toleration.Effect
+		pod.Spec.Tolerations[found].TolerationSeconds = toleration.TolerationSeconds
+	} else {
+		glog.Info("toleration not found, add")
+		pod.Spec.Tolerations = append(pod.Spec.Tolerations, *toleration)
+	}
+}
+
+// remove toleration from pod's spec
+func removeToleration(toleration *api.Toleration, pod *api.Pod) {
+	found := -1
+	for i, t := range pod.Spec.Tolerations {
+		if t.Key == toleration.Key && t.Operator == toleration.Operator && t.Value == toleration.Value {
+			found = i
+			break
+		}
+	}
+	// remove
+	// swap with last element of slice
+	if found != -1 {
+		glog.Infof("toleration found <%v>, remove", found)
+		lastElemIndex := len(pod.Spec.Tolerations) - 1
+		pod.Spec.Tolerations[found] = pod.Spec.Tolerations[lastElemIndex]
+		pod.Spec.Tolerations = pod.Spec.Tolerations[:lastElemIndex]
+	} else {
+		glog.Info("toleration is not found, do nothing")
+		// do nothing
+	}
+}
+
+// Admit will inject toleration for gpu dedicated nodes to pod if it needs gpu resource on creation
+func (p *plugin) Admit(a admission.Attributes) (err error) {
+	// Ignore all calls to subresources or resources other than pods.
+	if len(a.GetSubresource()) != 0 || a.GetResource().GroupResource() != api.Resource("pods") {
+		return nil
+	}
+	if a.GetOperation() != admission.Create {
+		return nil
+	}
+	pod, ok := a.GetObject().(*api.Pod)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+	}
+	toleration := api.Toleration{
+		Key:      defaultGPUTaintKey,
+		Operator: api.TolerationOpExists,
+	}
+	if !checkNeedGPU(pod) {
+		return nil
+	} else {
+		addToleration(&toleration, pod)
+	}
+	return nil
+}
+
+func (p *plugin) Handles(operation admission.Operation) bool {
+	if operation == admission.Create {
+		return true
+	}
+	return false
+}

--- a/plugin/pkg/admission/decorategpupod/admission_test.go
+++ b/plugin/pkg/admission/decorategpupod/admission_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+ Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package decorategpupod
+
+import (
+	"strconv"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/util/tolerations"
+)
+
+func getPod(name string, numContainers int, needGPU bool) *api.Pod {
+	res := api.ResourceRequirements{}
+	if needGPU {
+		res.Requests = api.ResourceList{api.ResourceNvidiaGPU: resource.MustParse("1")}
+		res.Limits = api.ResourceList{api.ResourceNvidiaGPU: resource.MustParse("1")}
+	}
+	pod := &api.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test"},
+		Spec:       api.PodSpec{},
+	}
+	pod.Spec.Containers = make([]api.Container, 0, numContainers)
+	for i := 0; i < numContainers; i++ {
+		pod.Spec.Containers = append(pod.Spec.Containers, api.Container{
+			Image:     "foo:V" + strconv.Itoa(i),
+			Resources: res,
+		})
+	}
+	return pod
+}
+
+func getToleration() *api.Toleration {
+	toleration := &api.Toleration{
+		Key:      "dedicated",
+		Operator: api.TolerationOpEqual,
+		Value:    "gpu",
+		Effect:   api.TaintEffectNoSchedule,
+	}
+	return toleration
+}
+
+func tolerationContains(toleration *api.Toleration, tolerationSlice []api.Toleration) bool {
+	for _, t := range tolerationSlice {
+		if tolerations.AreEqual(t, *toleration) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAdmitNeedGPUOnCreateShouldAddToleration(t *testing.T) {
+	handler := NewDecorateGPUPodPlugin()
+	newPod := getPod("test", 2, true)
+	err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler")
+	}
+	// check toleration
+	if !tolerationContains(getToleration(), newPod.Spec.Tolerations) {
+		t.Errorf("Check toleration failed")
+	}
+}
+
+func TestAdmitNeedGPUOnCreateShouldNotAddToleration(t *testing.T) {
+	handler := NewDecorateGPUPodPlugin()
+	newPod := getPod("test", 2, false)
+	err := handler.Admit(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler")
+	}
+	// check toleration
+	if tolerationContains(getToleration(), newPod.Spec.Tolerations) {
+		t.Errorf("Check toleration failed")
+	}
+}
+
+func TestHandles(t *testing.T) {
+	for op, shouldHandle := range map[admission.Operation]bool{
+		admission.Create:  true,
+		admission.Update:  false,
+		admission.Connect: false,
+		admission.Delete:  false,
+	} {
+		handler := NewDecorateGPUPodPlugin()
+		if e, a := shouldHandle, handler.Handles(op); e != a {
+			t.Errorf("%v: shouldHandle=%t, handles=%t", op, e, a)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add feature DecorateGPUPod to ke-release-1.9
Ref: https://github.com/qbox/kubernetes/pull/16
https://jira.qiniu.io/browse/KE-3031

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
