### PR TITLE
添加选项，ipvs模式kube-proxy可忽略LoadBalancer IP

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -149,6 +149,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&o.config.IPVS.SyncPeriod.Duration, "ipvs-sync-period", o.config.IPVS.SyncPeriod.Duration, "The maximum interval of how often ipvs rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.")
 	fs.DurationVar(&o.config.IPVS.MinSyncPeriod.Duration, "ipvs-min-sync-period", o.config.IPVS.MinSyncPeriod.Duration, "The minimum interval of how often the ipvs rules can be refreshed as endpoints and services change (e.g. '5s', '1m', '2h22m').")
 	fs.StringSliceVar(&o.config.IPVS.ExcludeCIDRs, "ipvs-exclude-cidrs", o.config.IPVS.ExcludeCIDRs, "A comma-separated list of CIDR's which the ipvs proxier should not touch when cleaning up IPVS rules.")
+	fs.BoolVar(&o.config.IPVS.IgnoreLoadBalancerIPs, "ipvs-ignore-loadbalancer-ips", o.config.IPVS.IgnoreLoadBalancerIPs, "Ignore ingress IPs of LoadBalancer typed services (leave them handled by cloud provider).")
 	fs.DurationVar(&o.config.ConfigSyncPeriod.Duration, "config-sync-period", o.config.ConfigSyncPeriod.Duration, "How often configuration from the apiserver is refreshed.  Must be greater than 0.")
 	fs.BoolVar(&o.config.IPTables.MasqueradeAll, "masquerade-all", o.config.IPTables.MasqueradeAll, "If using the pure iptables proxy, SNAT all traffic sent via Service cluster IPs (this not commonly needed)")
 	fs.StringVar(&o.config.ClusterCIDR, "cluster-cidr", o.config.ClusterCIDR, "The CIDR range of pods in the cluster. When configured, traffic sent to a Service cluster IP from outside this range will be masqueraded and traffic sent from pods to an external LoadBalancer IP will be directed to the respective cluster IP instead")

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"net"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -198,6 +198,7 @@ func newProxyServer(
 			recorder,
 			healthzServer,
 			config.IPVS.Scheduler,
+			config.IPVS.IgnoreLoadBalancerIPs,
 			config.NodePortAddresses,
 		)
 		if err != nil {

--- a/pkg/proxy/apis/kubeproxyconfig/types.go
+++ b/pkg/proxy/apis/kubeproxyconfig/types.go
@@ -70,6 +70,9 @@ type KubeProxyIPVSConfiguration struct {
 	// excludeCIDRs is a list of CIDR's which the ipvs proxier should not touch
 	// when cleaning up ipvs services.
 	ExcludeCIDRs []string
+	// ignoreLoadBalancerIPs set to true to ignore ingress IPs of LoadBalancer typed services.
+	// (leave them handled by cloud provider.)
+	IgnoreLoadBalancerIPs bool
 }
 
 // KubeProxyConntrackConfiguration contains conntrack settings for

--- a/pkg/proxy/apis/kubeproxyconfig/v1alpha1/types.go
+++ b/pkg/proxy/apis/kubeproxyconfig/v1alpha1/types.go
@@ -66,6 +66,9 @@ type KubeProxyIPVSConfiguration struct {
 	// excludeCIDRs is a list of CIDR's which the ipvs proxier should not touch
 	// when cleaning up ipvs services.
 	ExcludeCIDRs []string `json:"excludeCIDRs"`
+	// ignoreLoadBalancerIPs set to true to ignore ingress IPs of LoadBalancer typed services.
+	// (leave them handled by cloud provider.)
+	IgnoreLoadBalancerIPs bool `json:"ignoreLoadBalancerIPs"`
 }
 
 // KubeProxyConntrackConfiguration contains conntrack settings for

--- a/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.conversion.go
@@ -207,6 +207,7 @@ func autoConvert_v1alpha1_KubeProxyIPVSConfiguration_To_kubeproxyconfig_KubeProx
 	out.MinSyncPeriod = in.MinSyncPeriod
 	out.Scheduler = in.Scheduler
 	out.ExcludeCIDRs = *(*[]string)(unsafe.Pointer(&in.ExcludeCIDRs))
+	out.IgnoreLoadBalancerIPs = in.IgnoreLoadBalancerIPs
 	return nil
 }
 
@@ -220,6 +221,7 @@ func autoConvert_kubeproxyconfig_KubeProxyIPVSConfiguration_To_v1alpha1_KubeProx
 	out.MinSyncPeriod = in.MinSyncPeriod
 	out.Scheduler = in.Scheduler
 	out.ExcludeCIDRs = *(*[]string)(unsafe.Pointer(&in.ExcludeCIDRs))
+	out.IgnoreLoadBalancerIPs = in.IgnoreLoadBalancerIPs
 	return nil
 }
 

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -206,6 +206,8 @@ type Proxier struct {
 	healthChecker  healthcheck.Server
 	healthzServer  healthcheck.HealthzUpdater
 	ipvsScheduler  string
+	// set to true to ignore ingress IPs of LoadBalancer typed services.
+	ignoreLoadBalancerIPs bool
 	// Added as a member to the struct to allow injection for testing.
 	ipGetter IPGetter
 	// The following buffers are used to reuse memory and avoid allocations
@@ -309,6 +311,7 @@ func NewProxier(ipt utiliptables.Interface,
 	recorder record.EventRecorder,
 	healthzServer healthcheck.HealthzUpdater,
 	scheduler string,
+	ignoreLoadBalancerIPs bool,
 	nodePortAddresses []string,
 ) (*Proxier, error) {
 	// Set the route_localnet sysctl we need for
@@ -381,6 +384,7 @@ func NewProxier(ipt utiliptables.Interface,
 		healthzServer:         healthzServer,
 		ipvs:                  ipvs,
 		ipvsScheduler:         scheduler,
+		ignoreLoadBalancerIPs: ignoreLoadBalancerIPs,
 		ipGetter:              &realIPGetter{nl: NewNetLinkHandle()},
 		iptablesData:          bytes.NewBuffer(nil),
 		natChains:             bytes.NewBuffer(nil),
@@ -581,7 +585,7 @@ func CleanupLeftovers(ipvs utilipvs.Interface, ipt utiliptables.Interface, ipset
 		err = ipset.DestroySet(set.name)
 		if err != nil {
 			if !utilipset.IsNotFoundError(err) {
-				glog.Errorf("Error removing ipset %s, error: %v", set, err)
+				glog.Errorf("Error removing ipset %s, error: %v", set.name, err)
 				encounteredError = true
 			}
 		}
@@ -890,104 +894,106 @@ func (proxier *Proxier) syncProxyRules() {
 		}
 
 		// Capture load-balancer ingress.
-		for _, ingress := range svcInfo.LoadBalancerStatus.Ingress {
-			if ingress.IP != "" {
-				// ipset call
-				entry = &utilipset.Entry{
-					IP:       ingress.IP,
-					Port:     svcInfo.Port,
-					Protocol: protocol,
-					SetType:  utilipset.HashIPPort,
-				}
-				// add service load balancer ingressIP:Port to kubeServiceAccess ip set for the purpose of solving hairpin.
-				// proxier.kubeServiceAccessSet.activeEntries.Insert(entry.String())
-				// If we are proxying globally, we need to masquerade in case we cross nodes.
-				// If we are proxying only locally, we can retain the source IP.
-				if valid := proxier.ipsetList[kubeLoadBalancerSet].validateEntry(entry); !valid {
-					glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeLoadBalancerSet].Name))
-					continue
-				}
-				proxier.ipsetList[kubeLoadBalancerSet].activeEntries.Insert(entry.String())
-				// insert loadbalancer entry to lbIngressLocalSet if service externaltrafficpolicy=local
-				if svcInfo.OnlyNodeLocalEndpoints {
-					if valid := proxier.ipsetList[kubeLoadBalancerLocalSet].validateEntry(entry); !valid {
-						glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeLoadBalancerLocalSet].Name))
+		if !proxier.ignoreLoadBalancerIPs {
+			for _, ingress := range svcInfo.LoadBalancerStatus.Ingress {
+				if ingress.IP != "" {
+					// ipset call
+					entry = &utilipset.Entry{
+						IP:       ingress.IP,
+						Port:     svcInfo.Port,
+						Protocol: protocol,
+						SetType:  utilipset.HashIPPort,
+					}
+					// add service load balancer ingressIP:Port to kubeServiceAccess ip set for the purpose of solving hairpin.
+					// proxier.kubeServiceAccessSet.activeEntries.Insert(entry.String())
+					// If we are proxying globally, we need to masquerade in case we cross nodes.
+					// If we are proxying only locally, we can retain the source IP.
+					if valid := proxier.ipsetList[kubeLoadBalancerSet].validateEntry(entry); !valid {
+						glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeLoadBalancerSet].Name))
 						continue
 					}
-					proxier.ipsetList[kubeLoadBalancerLocalSet].activeEntries.Insert(entry.String())
-				}
-				if len(svcInfo.LoadBalancerSourceRanges) != 0 {
-					// The service firewall rules are created based on ServiceSpec.loadBalancerSourceRanges field.
-					// This currently works for loadbalancers that preserves source ips.
-					// For loadbalancers which direct traffic to service NodePort, the firewall rules will not apply.
-					if valid := proxier.ipsetList[kubeLoadbalancerFWSet].validateEntry(entry); !valid {
-						glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeLoadbalancerFWSet].Name))
-						continue
-					}
-					proxier.ipsetList[kubeLoadbalancerFWSet].activeEntries.Insert(entry.String())
-					allowFromNode := false
-					for _, src := range svcInfo.LoadBalancerSourceRanges {
-						// ipset call
-						entry = &utilipset.Entry{
-							IP:       ingress.IP,
-							Port:     svcInfo.Port,
-							Protocol: protocol,
-							Net:      src,
-							SetType:  utilipset.HashIPPortNet,
-						}
-						// enumerate all white list source cidr
-						if valid := proxier.ipsetList[kubeLoadBalancerSourceCIDRSet].validateEntry(entry); !valid {
-							glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeLoadBalancerSourceCIDRSet].Name))
+					proxier.ipsetList[kubeLoadBalancerSet].activeEntries.Insert(entry.String())
+					// insert loadbalancer entry to lbIngressLocalSet if service externaltrafficpolicy=local
+					if svcInfo.OnlyNodeLocalEndpoints {
+						if valid := proxier.ipsetList[kubeLoadBalancerLocalSet].validateEntry(entry); !valid {
+							glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeLoadBalancerLocalSet].Name))
 							continue
 						}
-						proxier.ipsetList[kubeLoadBalancerSourceCIDRSet].activeEntries.Insert(entry.String())
-
-						// ignore error because it has been validated
-						_, cidr, _ := net.ParseCIDR(src)
-						if cidr.Contains(proxier.nodeIP) {
-							allowFromNode = true
-						}
+						proxier.ipsetList[kubeLoadBalancerLocalSet].activeEntries.Insert(entry.String())
 					}
-					// generally, ip route rule was added to intercept request to loadbalancer vip from the
-					// loadbalancer's backend hosts. In this case, request will not hit the loadbalancer but loop back directly.
-					// Need to add the following rule to allow request on host.
-					if allowFromNode {
-						entry = &utilipset.Entry{
-							IP:       ingress.IP,
-							Port:     svcInfo.Port,
-							Protocol: protocol,
-							IP2:      ingress.IP,
-							SetType:  utilipset.HashIPPortIP,
-						}
-						// enumerate all white list source ip
-						if valid := proxier.ipsetList[kubeLoadBalancerSourceIPSet].validateEntry(entry); !valid {
-							glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeLoadBalancerSourceIPSet].Name))
+					if len(svcInfo.LoadBalancerSourceRanges) != 0 {
+						// The service firewall rules are created based on ServiceSpec.loadBalancerSourceRanges field.
+						// This currently works for loadbalancers that preserves source ips.
+						// For loadbalancers which direct traffic to service NodePort, the firewall rules will not apply.
+						if valid := proxier.ipsetList[kubeLoadbalancerFWSet].validateEntry(entry); !valid {
+							glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeLoadbalancerFWSet].Name))
 							continue
 						}
-						proxier.ipsetList[kubeLoadBalancerSourceIPSet].activeEntries.Insert(entry.String())
-					}
-				}
+						proxier.ipsetList[kubeLoadbalancerFWSet].activeEntries.Insert(entry.String())
+						allowFromNode := false
+						for _, src := range svcInfo.LoadBalancerSourceRanges {
+							// ipset call
+							entry = &utilipset.Entry{
+								IP:       ingress.IP,
+								Port:     svcInfo.Port,
+								Protocol: protocol,
+								Net:      src,
+								SetType:  utilipset.HashIPPortNet,
+							}
+							// enumerate all white list source cidr
+							if valid := proxier.ipsetList[kubeLoadBalancerSourceCIDRSet].validateEntry(entry); !valid {
+								glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeLoadBalancerSourceCIDRSet].Name))
+								continue
+							}
+							proxier.ipsetList[kubeLoadBalancerSourceCIDRSet].activeEntries.Insert(entry.String())
 
-				// ipvs call
-				serv := &utilipvs.VirtualServer{
-					Address:   net.ParseIP(ingress.IP),
-					Port:      uint16(svcInfo.Port),
-					Protocol:  string(svcInfo.Protocol),
-					Scheduler: proxier.ipvsScheduler,
-				}
-				if svcInfo.SessionAffinityType == api.ServiceAffinityClientIP {
-					serv.Flags |= utilipvs.FlagPersistent
-					serv.Timeout = uint32(svcInfo.StickyMaxAgeSeconds)
-				}
-				if err := proxier.syncService(svcNameString, serv, true); err == nil {
-					// check if service need skip endpoints that not in same host as kube-proxy
-					onlyLocal := svcInfo.SessionAffinityType == api.ServiceAffinityClientIP && svcInfo.OnlyNodeLocalEndpoints
-					activeIPVSServices[serv.String()] = true
-					if err := proxier.syncEndpoint(svcName, onlyLocal, serv); err != nil {
-						glog.Errorf("Failed to sync endpoint for service: %v, err: %v", serv, err)
+							// ignore error because it has been validated
+							_, cidr, _ := net.ParseCIDR(src)
+							if cidr.Contains(proxier.nodeIP) {
+								allowFromNode = true
+							}
+						}
+						// generally, ip route rule was added to intercept request to loadbalancer vip from the
+						// loadbalancer's backend hosts. In this case, request will not hit the loadbalancer but loop back directly.
+						// Need to add the following rule to allow request on host.
+						if allowFromNode {
+							entry = &utilipset.Entry{
+								IP:       ingress.IP,
+								Port:     svcInfo.Port,
+								Protocol: protocol,
+								IP2:      ingress.IP,
+								SetType:  utilipset.HashIPPortIP,
+							}
+							// enumerate all white list source ip
+							if valid := proxier.ipsetList[kubeLoadBalancerSourceIPSet].validateEntry(entry); !valid {
+								glog.Errorf("%s", fmt.Sprintf(EntryInvalidErr, entry, proxier.ipsetList[kubeLoadBalancerSourceIPSet].Name))
+								continue
+							}
+							proxier.ipsetList[kubeLoadBalancerSourceIPSet].activeEntries.Insert(entry.String())
+						}
 					}
-				} else {
-					glog.Errorf("Failed to sync service: %v, err: %v", serv, err)
+
+					// ipvs call
+					serv := &utilipvs.VirtualServer{
+						Address:   net.ParseIP(ingress.IP),
+						Port:      uint16(svcInfo.Port),
+						Protocol:  string(svcInfo.Protocol),
+						Scheduler: proxier.ipvsScheduler,
+					}
+					if svcInfo.SessionAffinityType == api.ServiceAffinityClientIP {
+						serv.Flags |= utilipvs.FlagPersistent
+						serv.Timeout = uint32(svcInfo.StickyMaxAgeSeconds)
+					}
+					if err := proxier.syncService(svcNameString, serv, true); err == nil {
+						// check if service need skip endpoints that not in same host as kube-proxy
+						onlyLocal := svcInfo.SessionAffinityType == api.ServiceAffinityClientIP && svcInfo.OnlyNodeLocalEndpoints
+						activeIPVSServices[serv.String()] = true
+						if err := proxier.syncEndpoint(svcName, onlyLocal, serv); err != nil {
+							glog.Errorf("Failed to sync endpoint for service: %v, err: %v", serv, err)
+						}
+					} else {
+						glog.Errorf("Failed to sync service: %v, err: %v", serv, err)
+					}
 				}
 			}
 		}

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -2595,6 +2595,7 @@ func TestCleanLegacyService(t *testing.T) {
 		nil,
 		nil,
 		DefaultScheduler,
+		false,
 		make([]string, 0),
 	)
 	if err != nil {


### PR DESCRIPTION
`kube-proxy`添加`--ipvs-ignore-loadbalancer-ip`选项，可配置ipvs模式下的kube-proxy忽略LoadBalancer类型的service的ingress IP。
JIRA issue: https://jira.qiniu.io/browse/KE-4447